### PR TITLE
Fail build on install error

### DIFF
--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -6,6 +6,8 @@ on:
     branches: devel
     paths:
       - 'DESCRIPTION'
+      - 'Dockerfile'
+      - '.github/workflows/build_container.yaml'
 
 jobs:
   check-wrapper:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,14 @@ RUN cd /tmp/repo && \
 
 COPY --chown=shiny:shiny app.R /srv/shiny-server/biocshiny/app.R
 
+RUN Rscript -e "if (!requireNamespace('BiocCertificate', quietly = TRUE)) { \
+    message('BiocCertificate did not install'); quit(status = 1) }; \
+    cat('BiocCertificate', format(packageVersion('BiocCertificate')), 'OK\n')" && \
+    Rscript -e "invisible(parse('/srv/shiny-server/biocshiny/app.R')); \
+    cat('app.R parses OK\n')" && \
+    Rscript -e "if (!tinytex::is_tinytex() && !nzchar(Sys.which('pdflatex'))) { \
+    message('no working TeX installation: certificates cannot be rendered'); \
+    quit(status = 1) }; \
+    cat('TeX OK\n')"
+
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@ FROM ghcr.io/bioconductor/shiny:devel AS build
 RUN chown -R shiny /usr/local/lib/R/site-library && \
     chown -R shiny /usr/local/lib/R/library && \
     rm -rf /srv/shiny-server/sample-apps && \
-    curl -o /srv/shiny-server/index.html \
+    curl -fsSL -o /srv/shiny-server/index.html \
     https://gist.githubusercontent.com/almahmoud/58261d03bfb342274f2e642c4b2ebc4d/raw/4e0271990bce57ae091f622db47b15f8fd89fa29/index.html && \
     mkdir -p /srv/shiny-server/biocshiny && \
     sed -i '/^run_as shiny;/a app_init_timeout 300;\napp_idle_timeout 300;' \
-    /etc/shiny-server/shiny-server.conf
+    /etc/shiny-server/shiny-server.conf && \
+    grep -q '^app_init_timeout 300;' /etc/shiny-server/shiny-server.conf
 
 RUN Rscript -e "options(repos = c(CRAN = 'https://p3m.dev/cran/__linux__/noble/latest')); \
     install.packages(c('remotes', 'BiocManager'))"


### PR DESCRIPTION
Fixes issue where GHA docker image build would silently pass even if it failed to install the package + some extra checks to prevent other things from silently failing, and make rebuild happen when Dockerfile or GHA are edited too 